### PR TITLE
Imun shared cache

### DIFF
--- a/langchain/utilities/__init__.py
+++ b/langchain/utilities/__init__.py
@@ -3,7 +3,7 @@ from langchain.python import PythonREPL
 from langchain.requests import RequestsWrapper
 from langchain.utilities.bash import BashProcess
 from langchain.utilities.bing_search import BingSearchAPIWrapper
-from langchain.utilities.imun import ImunAPIWrapper, ImunMultiAPIWrapper
+from langchain.utilities.imun import ImunAPIWrapper, ImunMultiAPIWrapper, ImunCache
 from langchain.utilities.google_search import GoogleSearchAPIWrapper
 from langchain.utilities.google_serper import GoogleSerperAPIWrapper
 from langchain.utilities.searx_search import SearxSearchWrapper
@@ -22,4 +22,5 @@ __all__ = [
     "BingSearchAPIWrapper",
     "ImunAPIWrapper",
     "ImunMultiAPIWrapper",
+    "ImunCache",
 ]


### PR DESCRIPTION
Option to cache API results and share among imuns.
Cache can be serialized and used for unit testing or evaluations without the need to call APIs